### PR TITLE
Make package actually work

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,31 @@
+name: Check build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # v2.3.1
+      with:
+        submodules: true
+
+    - name: Setup Node.js
+      uses: actions/setup-node@44c9c187283081e4e88b54b0efad9e9d468165a4 # v1.4.2
+      with:
+        node-version: '12'
+
+    - name: Build
+      run: |
+        mv ./grammars/cylc.json tmLang_copy.json
+        npm run build
+
+    - name: Check grammar file matches build output
+      run: diff -Z ./grammars/cylc.json tmLang_copy.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,8 @@
+## 1.0.1
+
+### Bug fixes
+- Package actually works now
+
 ## 1.0.0
-Initial release
+
+### Initial release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cylc language package for Atom
 
+![Check build](https://github.com/cylc/language-cylc/workflows/Check%20build/badge.svg?branch=master&event=push)
+
 An Atom extension that provides language support for Cylc workflow configuration files.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Please report any syntax highlighting issues at [cylc/cylc-textmate-grammar](htt
 
 This repo includes the [cylc/cylc-textmate-grammar](https://github.com/cylc/cylc-textmate-grammar) repo as a git submodule. If you don't have experience with submodules, you should [read the docs](https://git-scm.com/book/en/v2/Git-Tools-Submodules) first.
 
-The cylc-textmate-grammar repo contains a JSON TextMate grammar file which is used by Atom for syntax highlighting (symlinked to by `/grammars/cylc.json`). Read the [Atom guide on creating a TextMate grammar](https://flight-manual.atom.io/hacking-atom/sections/creating-a-legacy-textmate-grammar/) for more information. **Note:** do not edit the JSON file when contributing; instead you should edit the JavaScript grammar file and build it, as explained in the [contributing](https://github.com/cylc/cylc-textmate-grammar#contributing) section of cylc-texmate-grammar. Any edits will be part of that repo as opposed to this repo.
+The cylc-textmate-grammar repo contains a JSON TextMate grammar file which is used by Atom for syntax highlighting (after running the build process, see below). Read the [Atom guide on creating a TextMate grammar](https://flight-manual.atom.io/hacking-atom/sections/creating-a-legacy-textmate-grammar/) for more information. **Note:** do not edit the JSON file when contributing; instead you should edit the JavaScript grammar file and build it, as explained in the [contributing](https://github.com/cylc/cylc-textmate-grammar#contributing) section of cylc-texmate-grammar.
 
-On the other hand, any contributions to Atom-specific features are to be made in this repo, not the submodule.
 
 To install a development copy of the package:
 ```
@@ -44,5 +43,16 @@ git clone --recurse-submodules https://github.com/cylc/language-cylc.git
 cd language-cylc
 apm link --dev
 ```
-The `--recurse-submodules` option automatically initialises the cylc-textmate-grammar submodule. `apm link --dev` symlinks the clone to `~/.atom/dev/` so that it is loaded when you run Atom in dev mode.
+The `--recurse-submodules` option automatically initialises the cylc-textmate-grammar submodule. `apm link --dev` symlinks the clone to `~/.atom/dev/` so that it is loaded when you run Atom in dev mode:
+```
+atom --dev .
+```
 
+You can then edit the `/cylc-textmate-grammar/src/cylc.tmLanguage.js` grammar file. First, [read the contributing section](https://github.com/cylc/cylc-textmate-grammar#contributing) of the cylc-textmate-grammar repo - any such edits will be part of that repo as opposed to this vscode-cylc repo. After editing & saving the file, there is an npm build script:
+```
+npm run build
+```
+This will run the cylc-textmate-grammar build script which compiles the JSON grammar file, then copies it into `./grammars/cylc.json`. Reload the dev window using <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F5</kbd>.
+
+
+Contributions to Atom-specific features are to be made in this repo, not the submodule.

--- a/grammars/cylc.json
+++ b/grammars/cylc.json
@@ -1,1 +1,852 @@
-../cylc-textmate-grammar/cylc.tmLanguage.json
+{
+    "scopeName": "source.cylc",
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "fileTypes": [
+        "suite.rc",
+        "suite.rc.processed",
+        "cylc",
+        "flow.rc",
+        "flow-tests.rc"
+    ],
+    "name": "cylc",
+    "patterns": [
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#jinja2"
+        },
+        {
+            "include": "#graphSections"
+        },
+        {
+            "include": "#headers"
+        },
+        {
+            "include": "#settings"
+        },
+        {
+            "include": "#includeFiles"
+        },
+        {
+            "include": "#keywords"
+        },
+        {
+            "include": "#strings"
+        }
+    ],
+    "repository": {
+        "headers": {
+            "patterns": [
+                {
+                    "name": "meta.section.cylc",
+                    "match": "(\\[+)([^\\[\\]]+?)(\\]+)",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.begin.cylc"
+                        },
+                        "2": {
+                            "name": "entity.name.tag.cylc",
+                            "patterns": [
+                                {
+                                    "include": "#parameterizations"
+                                },
+                                {
+                                    "include": "#jinja2"
+                                }
+                            ]
+                        },
+                        "3": {
+                            "name": "punctuation.definition.tag.end.cylc"
+                        }
+                    },
+                    "comment": "@TODO handle `+`, `-`, `/` chars; convert to begin/end instead of match?"
+                }
+            ]
+        },
+        "graphSections": {
+            "patterns": [
+                {
+                    "comment": "Cylc 7 graph syntax",
+                    "begin": "\\b(graph)[\\t ]*(=)[\\t ]*",
+                    "end": "(?=[#\\n\\r])",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.graph.cylc"
+                        },
+                        "2": {
+                            "name": "keyword.operator.assignment.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#graphStrings"
+                        },
+                        {
+                            "comment": "In this situation, we cannot have string after string, or string on new line",
+                            "match": "(?:^|(?<=\"))[\\t ]*+([^#\\n\\r]+)",
+                            "captures": {
+                                "1": {
+                                    "name": "invalid.illegal.string.cylc"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "contentName": "meta.graph-section.cylc",
+                    "comment": "Cylc 8 graph syntax",
+                    "begin": "\\[{2}[\\t ]*graph[\\t ]*\\]{2}",
+                    "end": "(?=^[\\t ]*\\[)",
+                    "beginCaptures": {
+                        "0": {
+                            "patterns": [
+                                {
+                                    "include": "#headers"
+                                }
+                            ]
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        },
+                        {
+                            "begin": "(\\S[^=#]*)(=)[\\t ]*",
+                            "end": "(?=[#\\n\\r])",
+                            "beginCaptures": {
+                                "1": {
+                                    "patterns": [
+                                        {
+                                            "include": "#jinja2"
+                                        },
+                                        {
+                                            "name": "keyword.graph.cylc",
+                                            "match": "[\\w\\+\\^\\$][\\w\\+\\-\\^\\$\\/\\t ,:]*"
+                                        }
+                                    ]
+                                },
+                                "2": {
+                                    "name": "keyword.operator.assignment.cylc"
+                                }
+                            },
+                            "patterns": [
+                                {
+                                    "include": "#graphStrings"
+                                },
+                                {
+                                    "comment": "In this situation, we cannot have string after string, or string on new line",
+                                    "match": "(?:^|(?<=\"))[\\t ]*+([^#\\n\\r]+)",
+                                    "captures": {
+                                        "1": {
+                                            "name": "invalid.illegal.string.cylc"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "graphStrings": {
+            "patterns": [
+                {
+                    "name": "meta.graph-syntax.quoted.triple.cylc",
+                    "begin": "\\G(\"{3})",
+                    "end": "(\"{3})",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "string.quoted.triple.cylc"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.string.begin.cylc"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "string.quoted.triple.cylc"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.string.end.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#graphSyntax"
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.graph-syntax.quoted.double.cylc",
+                    "begin": "\\G(\")",
+                    "end": "([\"\\n\\r])",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "string.quoted.double.cylc"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.string.begin.cylc"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "string.quoted.double.cylc"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.string.end.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#graphSyntax"
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.graph-syntax.unquoted.cylc",
+                    "match": "\\G[^#\\n\\r\"]+",
+                    "captures": {
+                        "0": {
+                            "patterns": [
+                                {
+                                    "include": "#graphSyntax"
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "graphSyntax": {
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#parameterizations"
+                },
+                {
+                    "include": "#jinja2"
+                },
+                {
+                    "name": "meta.variable.task.cylc",
+                    "match": "\\b\\w[\\w\\+\\-@%]*"
+                },
+                {
+                    "name": "keyword.control.trigger.cylc",
+                    "match": "=>"
+                },
+                {
+                    "name": "keyword.other.logical.cylc",
+                    "match": "[\\|&]"
+                },
+                {
+                    "name": "meta.parens.cylc",
+                    "begin": "\\(",
+                    "end": "[\\)\\n\\r]",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.section.parens.begin.cylc"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.parens.end.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#graphSyntax"
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.variable.suicide.cylc",
+                    "match": "(?<=^|[\\s&>])(!)(\\b\\w[\\w\\+\\-@%]*)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.suicide.cylc"
+                        },
+                        "2": {
+                            "name": "meta.variable.task.cylc"
+                        }
+                    }
+                },
+                {
+                    "name": "variable.other.xtrigger.cylc",
+                    "match": "(@)[\\w\\-]+",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.variable.cylc"
+                        }
+                    }
+                },
+                {
+                    "name": "constant.character.escape.continuation.cylc",
+                    "match": "\\\\"
+                },
+                {
+                    "comment": "e.g. foo:fail => bar",
+                    "match": "(?<!^|[\\s:])((:)([\\w\\-]+))",
+                    "captures": {
+                        "1": {
+                            "name": "meta.annotation.qualifier.cylc"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.annotation.cylc"
+                        },
+                        "3": {
+                            "name": "variable.annotation.cylc"
+                        }
+                    }
+                },
+                {
+                    "name": "meta.annotation.inter-cycle.cylc",
+                    "comment": "e.g. foo[-P1]",
+                    "begin": "(?<=\\S)\\[",
+                    "end": "\\]",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.section.brackets.begin.cylc"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.brackets.end.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#jinja2"
+                        },
+                        {
+                            "include": "#intervals"
+                        },
+                        {
+                            "include": "#isodatetimes"
+                        },
+                        {
+                            "comment": "If 1st char is ^ (allowing for spaces)",
+                            "match": "\\G[\\t ]*(\\^)",
+                            "captures": {
+                                "1": {
+                                    "name": "constant.language.cycle-point.cylc"
+                                }
+                            }
+                        },
+                        {
+                            "name": "keyword.operator.arithmetic.cylc",
+                            "match": "[\\+\\-]"
+                        },
+                        {
+                            "name": "constant.numeric.integer-point.cylc",
+                            "comment": "Integer as long as it isn't adjacent to a letter",
+                            "match": "\\b\\d+\\b"
+                        }
+                    ]
+                }
+            ]
+        },
+        "settings": {
+            "patterns": [
+                {
+                    "name": "meta.setting.cylc",
+                    "begin": "([^=#\\s][^=#\\n\\r]*?)?[\\t ]*(=)[\\t ]*",
+                    "end": "(?=[#\\n\\r])",
+                    "beginCaptures": {
+                        "1": {
+                            "patterns": [
+                                {
+                                    "include": "#jinja2"
+                                },
+                                {
+                                    "name": "variable.other.key.cylc",
+                                    "match": "[\\w\\-\\t ]+"
+                                }
+                            ]
+                        },
+                        "2": {
+                            "name": "keyword.operator.assignment.cylc"
+                        }
+                    },
+                    "contentName": "meta.value.cylc",
+                    "patterns": [
+                        {
+                            "include": "#strings"
+                        },
+                        {
+                            "comment": "In this situation, we cannot have string after string, or string on new line",
+                            "match": "(?:^|(?<=\"))[\\t ]*+([^#\\n\\r]+)",
+                            "captures": {
+                                "1": {
+                                    "name": "invalid.illegal.string.cylc"
+                                }
+                            }
+                        },
+                        {
+                            "include": "#jinja2"
+                        },
+                        {
+                            "match": "([^#\\n\\r]+)",
+                            "captures": {
+                                "1": {
+                                    "name": "string.unquoted.value.cylc",
+                                    "patterns": [
+                                        {
+                                            "include": "#jinja2"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "includeFiles": {
+            "patterns": [
+                {
+                    "name": "meta.include.cylc",
+                    "match": "(%include)[\\t ]*(.*)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.include.cylc"
+                        },
+                        "2": {
+                            "name": "string.cylc",
+                            "patterns": [
+                                {
+                                    "include": "#comments"
+                                },
+                                {
+                                    "include": "#jinja2"
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "name": "keyword.control.cylc",
+                    "match": "\\b(if|for|while|return)\\b"
+                }
+            ]
+        },
+        "strings": {
+            "patterns": [
+                {
+                    "name": "string.quoted.triple.cylc",
+                    "begin": "(\"{3})",
+                    "end": "(\"{3})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.begin.cylc"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#jinja2"
+                        },
+                        {
+                            "name": "constant.character.escape.cylc",
+                            "match": "\\\\."
+                        }
+                    ]
+                },
+                {
+                    "name": "string.quoted.double.cylc",
+                    "begin": "(\")",
+                    "end": "([\"\\n\\r])",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.begin.cylc"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#jinja2"
+                        },
+                        {
+                            "name": "constant.character.escape.cylc",
+                            "match": "\\\\."
+                        }
+                    ]
+                }
+            ]
+        },
+        "comments": {
+            "patterns": [
+                {
+                    "name": "comment.line.cylc",
+                    "match": "(#).*",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.comment.cylc"
+                        }
+                    }
+                }
+            ]
+        },
+        "parameterizations": {
+            "patterns": [
+                {
+                    "name": "meta.annotation.parameterization.cylc",
+                    "begin": "<",
+                    "end": ">",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.annotation.begin.cylc"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.annotation.end.cylc"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#jinja2"
+                        },
+                        {
+                            "name": "meta.polling.cylc",
+                            "patterns": [
+                                {
+                                    "match": "([^\\s<>]+)(?=::)",
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.name.namespace.suite.cylc"
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "punctuation.accessor.cylc",
+                                    "match": "(?<=\\S)::(?=\\S)"
+                                },
+                                {
+                                    "match": "(?<=::)(\\b\\w[\\w\\+\\-@%]*)",
+                                    "captures": {
+                                        "1": {
+                                            "name": "meta.variable.task.cylc"
+                                        }
+                                    }
+                                },
+                                {
+                                    "comment": "e.g. foo:fail => bar",
+                                    "match": "(?<!^|[\\s:])((:)([\\w\\-]+))",
+                                    "captures": {
+                                        "1": {
+                                            "name": "meta.annotation.qualifier.cylc"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.definition.annotation.cylc"
+                                        },
+                                        "3": {
+                                            "name": "variable.annotation.cylc"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "match": "(\\w+)[\\t ]*(=)[\\t ]*(\\w+)",
+                            "captures": {
+                                "1": {
+                                    "name": "variable.parameter.cylc"
+                                },
+                                "2": {
+                                    "name": "keyword.operator.assignment.cylc"
+                                },
+                                "3": {
+                                    "patterns": [
+                                        {
+                                            "name": "constant.numeric.cylc",
+                                            "match": "\\d+$"
+                                        },
+                                        {
+                                            "name": "variable.other.cylc",
+                                            "match": "\\w+"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "match": "([\\+\\-])[\\t ]*(\\d+)(?!\\w)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.operator.arithmetic.cylc"
+                                },
+                                "2": {
+                                    "name": "constant.numeric.cylc"
+                                }
+                            }
+                        },
+                        {
+                            "name": "variable.parameter.cylc",
+                            "match": "\\w+"
+                        },
+                        {
+                            "name": "punctuation.separator.parameter.cylc",
+                            "match": ","
+                        }
+                    ]
+                }
+            ]
+        },
+        "isodatetimes": {
+            "patterns": [
+                {
+                    "name": "invalid.illegal.isodatetime.cylc",
+                    "comment": "Malformed isodatetime e.g. 2000T00",
+                    "match": "\\b\\d{3,7}T\\d{2,}Z?\\b"
+                },
+                {
+                    "name": "invalid.illegal.isodatetime.cylc",
+                    "comment": "Mixed long/short syntaxes e.g. 2000-12-01T0600",
+                    "match": "\\b(\\d{4})(?:(\\-)(\\d{2}))?(?:(\\-)(\\d{2}))?T\\d{3,}\\b"
+                },
+                {
+                    "name": "invalid.illegal.isodatetime.cylc",
+                    "comment": "Mixed long/short syntaxes e.g. 20001201T06:00, 20001201T06+05:30",
+                    "match": "\\b(\\d{4})(\\d{2})?(\\d{2})?T\\d{2,}(?:[\\+\\-]\\d+)?\\:\\d*\\b"
+                },
+                {
+                    "name": "constant.numeric.isodatetime.long.cylc",
+                    "match": "\\b(\\d{4})(?:(\\-)(\\d{2}))?(?:(\\-)(\\d{2}))?(?:(T)(\\d{2})(?:(:)(\\d{2}))?(?:(:)(\\d{2}))?((Z)|(?:([\\+\\-])(\\d{2})(?:(\\:)(\\d{2}))?))?)?\\b",
+                    "captures": {
+                        "1": {
+                            "name": "constant.numeric.year.cylc"
+                        },
+                        "2": {
+                            "name": "punctuation.separator.date.cylc"
+                        },
+                        "3": {
+                            "name": "constant.numeric.month.cylc"
+                        },
+                        "4": {
+                            "name": "punctuation.separator.date.cylc"
+                        },
+                        "5": {
+                            "name": "constant.numeric.day.cylc"
+                        },
+                        "6": {
+                            "name": "punctuation.definition.time.cylc"
+                        },
+                        "7": {
+                            "name": "constant.numeric.hour.cylc"
+                        },
+                        "8": {
+                            "name": "punctuation.separator.time.cylc"
+                        },
+                        "9": {
+                            "name": "constant.numeric.min.cylc"
+                        },
+                        "10": {
+                            "name": "punctuation.separator.time.cylc"
+                        },
+                        "11": {
+                            "name": "constant.numeric.sec.cylc"
+                        },
+                        "12": {
+                            "name": "constant.numeric.timezone.long.cylc"
+                        },
+                        "13": {
+                            "name": "punctuation.definition.timezone.cylc"
+                        },
+                        "14": {
+                            "name": "punctuation.definition.timezone.cylc"
+                        },
+                        "15": {
+                            "name": "constant.numeric.hour.cylc"
+                        },
+                        "16": {
+                            "name": "punctuation.separator.time.cylc"
+                        },
+                        "17": {
+                            "name": "constant.numeric.min.cylc"
+                        }
+                    }
+                },
+                {
+                    "name": "constant.numeric.isodatetime.short.cylc",
+                    "match": "\\b(\\d{4})(\\d{2})?(\\d{2})?(?:(T)(\\d{2})(\\d{2})?(\\d{2})?((Z)|(?:([\\+\\-])(\\d{2})(\\d{2})?))?)?\\b",
+                    "captures": {
+                        "1": {
+                            "name": "constant.numeric.year.cylc"
+                        },
+                        "2": {
+                            "name": "constant.numeric.month.cylc"
+                        },
+                        "3": {
+                            "name": "constant.numeric.day.cylc"
+                        },
+                        "4": {
+                            "name": "punctuation.definition.time.cylc"
+                        },
+                        "5": {
+                            "name": "constant.numeric.hour.cylc"
+                        },
+                        "6": {
+                            "name": "constant.numeric.min.cylc"
+                        },
+                        "7": {
+                            "name": "constant.numeric.sec.cylc"
+                        },
+                        "8": {
+                            "name": "constant.numeric.isotimezone.short.cylc"
+                        },
+                        "9": {
+                            "name": "punctuation.definition.timezone.cylc"
+                        },
+                        "10": {
+                            "name": "punctuation.definition.timezone.cylc"
+                        },
+                        "11": {
+                            "name": "constant.numeric.hour.cylc"
+                        },
+                        "12": {
+                            "name": "constant.numeric.min.cylc"
+                        }
+                    }
+                }
+            ]
+        },
+        "intervals": {
+            "patterns": [
+                {
+                    "name": "invalid.illegal.interval.cylc",
+                    "comment": "e.g. P1H without T separator",
+                    "match": "\\bP\\d+[HS]"
+                },
+                {
+                    "name": "constant.numeric.interval.integer.cylc",
+                    "comment": "e.g. P1 but not P1D",
+                    "match": "\\b(P)\\d+\\b",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.period.cylc"
+                        }
+                    }
+                },
+                {
+                    "name": "constant.numeric.interval.iso.cylc",
+                    "comment": "e.g. P1W",
+                    "match": "\\b(P)\\d+(W)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.period.cylc"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.week.cylc"
+                        }
+                    }
+                },
+                {
+                    "name": "constant.numeric.interval.iso.cylc",
+                    "comment": "e.g. P1Y1M1DT1H1M1S, P1D, PT1M. (P(?=(?:\\d|T\\d))) captures P only if followed by a digit or T. (?:\\d+(Y))? matches e.g. 1Y zero or more times, etc.",
+                    "match": "\\b(P(?=(?:\\d|T\\d)))(?:\\d+(Y))?(?:\\d+(M))?(?:\\d+(D))?(?:(T)(?:\\d+(H))?(?:\\d+(M))?(?:\\d+(S))?)?\\b",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.period.cylc"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.year.cylc"
+                        },
+                        "3": {
+                            "name": "punctuation.definition.month.cylc"
+                        },
+                        "4": {
+                            "name": "punctuation.definition.day.cylc"
+                        },
+                        "5": {
+                            "name": "punctuation.definition.time.cylc"
+                        },
+                        "6": {
+                            "name": "punctuation.definition.hour.cylc"
+                        },
+                        "7": {
+                            "name": "punctuation.definition.min.cylc"
+                        },
+                        "8": {
+                            "name": "punctuation.definition.sec.cylc"
+                        }
+                    }
+                }
+            ]
+        },
+        "jinja2": {
+            "patterns": [
+                {
+                    "name": "meta.embedded.block.jinja",
+                    "comment": "e.g. {% ... %}",
+                    "begin": "(?={%)",
+                    "end": "(?<=%})",
+                    "contentName": "source.jinja",
+                    "patterns": [
+                        {
+                            "include": "source.jinja"
+                        },
+                        {
+                            "match": "\\G{%[\\+\\-]?",
+                            "name": "punctuation.definition.template-expression.begin.jinja"
+                        },
+                        {
+                            "match": "\\-?%}",
+                            "name": "punctuation.definition.template-expression.end.jinja"
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.embedded.block.jinja",
+                    "comment": "e.g. {{ ... }}",
+                    "begin": "(?={{)",
+                    "end": "(?<=}})",
+                    "contentName": "source.jinja",
+                    "patterns": [
+                        {
+                            "include": "source.jinja"
+                        },
+                        {
+                            "match": "\\G{{",
+                            "name": "punctuation.definition.template-expression.begin.jinja"
+                        },
+                        {
+                            "match": "}}",
+                            "name": "punctuation.definition.template-expression.end.jinja"
+                        }
+                    ]
+                },
+                {
+                    "name": "comment.block.jinja",
+                    "comment": "e.g. {# ... #}",
+                    "begin": "{#",
+                    "end": "#}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.begin.jinja"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.end.jinja"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "license": "GPL-3.0",
     "engines": {
         "atom": ">=1.0.0 <2.0.0"
+    },
+    "scripts": {
+        "build": "npm run --prefix ./cylc-textmate-grammar/ build && cp --remove-destination ./cylc-textmate-grammar/cylc.tmLanguage.json ./grammars/cylc.json && echo 'grammars/cylc.json successfully updated'"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "language-cylc",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Atom language package for Cylc workflow configuration files",
     "repository": "https://github.com/cylc/language-cylc",
     "license": "GPL-3.0",


### PR DESCRIPTION
The Atom package manager `apm` doesn't fetch submodules, so if you installed v1.0.0 from Settings, you got an empty package. Also the symlink `grammars/cylc.json` would be missing too. (Thanks to @datamel for helping me debug this!)

I've replaced the symlink with a hard copy of `cylc-textmate-grammar/cylc.tmLanguage.json`. This necessitates a build step to copy over the most recent build of the tmLanguage. 