### PR TITLE
Make package actually work - 2nd attempt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,21 @@ jobs:
         rm -f "$TEMP_DEB"
         apm --version
 
+    - name: Prepare grammar file & push updated release # Has to be before Publish step
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        git checkout -b "latest-release"
+        cp --remove-destination ./cylc-textmate-grammar/cylc.tmLanguage.json ./grammars/cylc.json
+        echo "grammars/cylc.json symlink updated to hard copy"
+
+        git commit -a -m "CI release" -m "Workflow: ${{ github.workflow }}, run: ${{ github.run_number }}"
+
+        git push -f origin latest-release
+        # Update tag on origin to this commit:
+        git push -f origin HEAD:${{ github.ref }}
+
     - name: Publish
       env:
         ATOM_ACCESS_TOKEN: ${{ secrets.ATOM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,8 @@
+## 1.0.1
+
+### Bug fixes
+- Package actually works now
+
 ## 1.0.0
-Initial release
+
+### Initial release

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ Please report any syntax highlighting issues at [cylc/cylc-textmate-grammar](htt
 
 This repo includes the [cylc/cylc-textmate-grammar](https://github.com/cylc/cylc-textmate-grammar) repo as a git submodule. If you don't have experience with submodules, you should [read the docs](https://git-scm.com/book/en/v2/Git-Tools-Submodules) first.
 
-The cylc-textmate-grammar repo contains a JSON TextMate grammar file which is used by Atom for syntax highlighting (symlinked to by `/grammars/cylc.json`). Read the [Atom guide on creating a TextMate grammar](https://flight-manual.atom.io/hacking-atom/sections/creating-a-legacy-textmate-grammar/) for more information. **Note:** do not edit the JSON file when contributing; instead you should edit the JavaScript grammar file and build it, as explained in the [contributing](https://github.com/cylc/cylc-textmate-grammar#contributing) section of cylc-texmate-grammar. Any edits will be part of that repo as opposed to this repo.
-
-On the other hand, any contributions to Atom-specific features are to be made in this repo, not the submodule.
+The cylc-textmate-grammar repo contains a JSON TextMate grammar file which is used by Atom for syntax highlighting (symlinked to by `grammars/cylc.json`). Read the [Atom guide on creating a TextMate grammar](https://flight-manual.atom.io/hacking-atom/sections/creating-a-legacy-textmate-grammar/) for more information. **Note:** do not edit the JSON file when contributing; instead you should edit the JavaScript grammar file and build it, as explained in the [contributing](https://github.com/cylc/cylc-textmate-grammar#contributing) section of cylc-texmate-grammar. Any edits will be part of that repo as opposed to this repo.
 
 To install a development copy of the package:
 ```
@@ -44,5 +42,11 @@ git clone --recurse-submodules https://github.com/cylc/language-cylc.git
 cd language-cylc
 apm link --dev
 ```
-The `--recurse-submodules` option automatically initialises the cylc-textmate-grammar submodule. `apm link --dev` symlinks the clone to `~/.atom/dev/` so that it is loaded when you run Atom in dev mode.
+The `--recurse-submodules` option automatically initialises the cylc-textmate-grammar submodule. `apm link --dev` symlinks the clone to `~/.atom/dev/` so that it is loaded when you run Atom in dev mode:
+```
+atom --dev .
+```
 
+You can then edit the `cylc-textmate-grammar/src/cylc.tmLanguage.js` grammar file. First, [read the contributing section](https://github.com/cylc/cylc-textmate-grammar#contributing) of the cylc-textmate-grammar repo - any such edits will be part of that repo as opposed to this vscode-cylc repo. Remember to run `npm build` inside `cylc-texmate-grammar` after editing & saving the file. Reload the dev window using <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F5</kbd>.
+
+Contributions to Atom-specific features are to be made in this repo, not the submodule.

--- a/owners.md
+++ b/owners.md
@@ -5,13 +5,16 @@
 
 ## Deploying
 
-Publishing updates to the Atom package registry is done automatically by GitHub Actions when a release is published. The suggested workflow is:
+Publishing updates to the Atom package registry is done automatically by GitHub Actions when a release is published. The suggested process is:
 1. Merge the pull request(s) with changes
-1. Bump the `package.json` version, and create a PR (1 reviewer is fine)
+1. Bump the `package.json` version, update the changelog and create a PR (1 reviewer is fine)
 1. Publish a release on GitHub with a tag matching the version number
 
 If the Deploy workflow fails because you forgot to bump the `package.json` version, the tag associated with the release will be automatically deleted and the release will become a draft. Simply bump the `package.json` version as appropriate and re-publish the release to trigger the workflow again.
 
+
 ### Information on publishing Atom packages
 
 Publishing is done by `apm`. See https://flight-manual.atom.io/behind-atom/sections/maintaining-your-packages/. The Atom token of a member of the Cylc organization (gotten from signing in at [atom.io](https://atom.io)) needs to be [stored as a repository secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets). The token of any member of the organization (with push access) will do.
+
+The Deploy workflow also replaces the symlink `grammars/cylc.json` with a hard copy of `cylc-textmate-grammar/cylc.tmLanguage.json` in a tag that dangles off master, because `apm` doesn't pull submodules - see [#3](https://github.com/cylc/language-cylc/pull/3).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "language-cylc",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Atom language package for Cylc workflow configuration files",
     "repository": "https://github.com/cylc/language-cylc",
     "license": "GPL-3.0",


### PR DESCRIPTION
Following from the discussion on #2

The Atom package manager `apm` doesn't fetch submodules, so if you installed v1.0.0 from Settings, you got an empty package. Also the symlink `grammars/cylc.json` would be missing too. (Thanks to @datamel for helping me debug this!)

In the GH Actions Deploy workflow, it now
1. Replaces the symlink with a hard copy of `cylc-textmate-grammar/cylc.tmLanguage.json`
1. Commits this change
1. Updates the release tag on origin to point to this new commit (so the tag is dangling off master)
1. Finally runs the `apm publish` step, which should fetch the updated tag

