### PR TITLE
GH Actions: upgrade deprecated set-env command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         tag=$( node ./.github/bin/get-version-tag ${{ github.ref }} )
         echo "Tag: ${tag}"
-        echo "::set-env name=VERSION_TAG::$tag"
+        echo "VERSION_TAG=$tag" >> $GITHUB_ENV
 
     - name: Install apm (with Atom)
       env:


### PR DESCRIPTION
See [the GitHub changelog announcement](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and [the docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).

1 reviewer should be enough
